### PR TITLE
Missing dep in std_msgs

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -13,6 +13,6 @@ Maintainer: Troy Straszheim <straszheim@willowgarage.com>
 Homepage: http://www.ros.org
 Catkin-DebRulesType: cmake
 Catkin-CopyrightType:  willowgarage
-Catkin-Depends: catkin, genmsg
+Catkin-Depends: catkin, genmsg, genpybindings
 Catkin-ProjectName: std_msgs
 


### PR DESCRIPTION
Perhaps this will help with the occasional parallel build failures we've seen on Linux...
