### PR TITLE
package.xml: removing trailing whitespaces

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -6,7 +6,7 @@
     For common, generic robot-specific message types, please see <a href="http://www.ros.org/wiki/common_msgs">common_msgs</a>.
   </description>
   <maintainer email="tfoote@osrfoundation.org">Tully Foote</maintainer>
-  <license>BSD</license>  
+  <license>BSD</license>
 
   <url type="website">http://www.ros.org/wiki/std_msgs</url>
   <url type="repository">https://github.com/ros/std_msgs</url>


### PR DESCRIPTION
This commit removes trailing whitespaces and makes the line with the license information in the package.xml bitwise match exactly the common license information line in most ROS packages.
The trailing whitespaces were detected when providing a bitbake recipe in the meta-ros project (github.com/bmwcarit/meta-ros). In the recipe, the hash of the license line is declared and is used to check for changes in the license. For this recipe, it was not matching the common one.
