### PR TITLE
Update Header.msg

### DIFF
--- a/msg/Header.msg
+++ b/msg/Header.msg
@@ -5,8 +5,8 @@
 # sequence ID: consecutively increasing ID 
 uint32 seq
 #Two-integer timestamp that is expressed as:
-# * stamp.secs: seconds (stamp_secs) since epoch
-# * stamp.nsecs: nanoseconds since stamp_secs
+# * stamp.sec: seconds (stamp_secs) since epoch
+# * stamp.nsec: nanoseconds since stamp_secs
 # time-handling sugar is provided by the client library
 time stamp
 #Frame this data is associated with


### PR DESCRIPTION
Comment in header message is misleading. Actual field names for time data is singular, not plural.
