### PR TITLE
fix extra ‘;’ warnings when compiling with -Wpedantic

### DIFF
--- a/include/std_msgs/builtin_bool.h
+++ b/include/std_msgs/builtin_bool.h
@@ -31,6 +31,6 @@
 #include "trait_macros.h"
 #include <std_msgs/Bool.h>
 
-STD_MSGS_DEFINE_BUILTIN_TRAITS(bool, Bool, 0x8b94c1b53db61fb6ULL, 0xaed406028ad6332aULL);
+STD_MSGS_DEFINE_BUILTIN_TRAITS(bool, Bool, 0x8b94c1b53db61fb6ULL, 0xaed406028ad6332aULL)
 
 #endif

--- a/include/std_msgs/builtin_double.h
+++ b/include/std_msgs/builtin_double.h
@@ -31,6 +31,6 @@
 #include "trait_macros.h"
 #include <std_msgs/Float64.h>
 
-STD_MSGS_DEFINE_BUILTIN_TRAITS(double, Float64, 0xfdb28210bfa9d7c9ULL, 0x1146260178d9a584ULL);
+STD_MSGS_DEFINE_BUILTIN_TRAITS(double, Float64, 0xfdb28210bfa9d7c9ULL, 0x1146260178d9a584ULL)
 
 #endif

--- a/include/std_msgs/builtin_float.h
+++ b/include/std_msgs/builtin_float.h
@@ -31,6 +31,6 @@
 #include "trait_macros.h"
 #include <std_msgs/Float32.h>
 
-STD_MSGS_DEFINE_BUILTIN_TRAITS(float, Float32, 0x73fcbf46b49191e6ULL, 0x72908e50842a83d4ULL);
+STD_MSGS_DEFINE_BUILTIN_TRAITS(float, Float32, 0x73fcbf46b49191e6ULL, 0x72908e50842a83d4ULL)
 
 #endif

--- a/include/std_msgs/builtin_int16.h
+++ b/include/std_msgs/builtin_int16.h
@@ -31,6 +31,6 @@
 #include "trait_macros.h"
 #include <std_msgs/Int16.h>
 
-STD_MSGS_DEFINE_BUILTIN_TRAITS(int16_t, Int16, 0x8524586e34fbd7cbULL, 0x1c08c5f5f1ca0e57ULL);
+STD_MSGS_DEFINE_BUILTIN_TRAITS(int16_t, Int16, 0x8524586e34fbd7cbULL, 0x1c08c5f5f1ca0e57ULL)
 
 #endif

--- a/include/std_msgs/builtin_int32.h
+++ b/include/std_msgs/builtin_int32.h
@@ -31,6 +31,6 @@
 #include "trait_macros.h"
 #include <std_msgs/Int32.h>
 
-STD_MSGS_DEFINE_BUILTIN_TRAITS(int32_t, Int32, 0xda5909fbe378aeafULL, 0x85e547e830cc1bb7ULL);
+STD_MSGS_DEFINE_BUILTIN_TRAITS(int32_t, Int32, 0xda5909fbe378aeafULL, 0x85e547e830cc1bb7ULL)
 
 #endif

--- a/include/std_msgs/builtin_int64.h
+++ b/include/std_msgs/builtin_int64.h
@@ -31,6 +31,6 @@
 #include "trait_macros.h"
 #include <std_msgs/Int64.h>
 
-STD_MSGS_DEFINE_BUILTIN_TRAITS(int64_t, Int64, 0x34add168574510e6ULL, 0xe17f5d23ecc077efULL);
+STD_MSGS_DEFINE_BUILTIN_TRAITS(int64_t, Int64, 0x34add168574510e6ULL, 0xe17f5d23ecc077efULL)
 
 #endif

--- a/include/std_msgs/builtin_int8.h
+++ b/include/std_msgs/builtin_int8.h
@@ -31,6 +31,6 @@
 #include "trait_macros.h"
 #include <std_msgs/Int8.h>
 
-STD_MSGS_DEFINE_BUILTIN_TRAITS(int8_t, Int8, 0x27ffa0c9c4b8fb84ULL, 0x92252bcad9e5c57bULL);
+STD_MSGS_DEFINE_BUILTIN_TRAITS(int8_t, Int8, 0x27ffa0c9c4b8fb84ULL, 0x92252bcad9e5c57bULL)
 
 #endif

--- a/include/std_msgs/builtin_uint16.h
+++ b/include/std_msgs/builtin_uint16.h
@@ -31,6 +31,6 @@
 #include "trait_macros.h"
 #include <std_msgs/UInt16.h>
 
-STD_MSGS_DEFINE_BUILTIN_TRAITS(uint16_t, UInt16, 0x1df79edf208b629fULL, 0xe6b81923a544552dULL);
+STD_MSGS_DEFINE_BUILTIN_TRAITS(uint16_t, UInt16, 0x1df79edf208b629fULL, 0xe6b81923a544552dULL)
 
 #endif

--- a/include/std_msgs/builtin_uint32.h
+++ b/include/std_msgs/builtin_uint32.h
@@ -31,6 +31,6 @@
 #include "trait_macros.h"
 #include <std_msgs/UInt32.h>
 
-STD_MSGS_DEFINE_BUILTIN_TRAITS(uint32_t, UInt32, 0x304a39449588c7f8ULL, 0xce2df6e8001c5fceULL);
+STD_MSGS_DEFINE_BUILTIN_TRAITS(uint32_t, UInt32, 0x304a39449588c7f8ULL, 0xce2df6e8001c5fceULL)
 
 #endif

--- a/include/std_msgs/builtin_uint64.h
+++ b/include/std_msgs/builtin_uint64.h
@@ -31,6 +31,6 @@
 #include "trait_macros.h"
 #include <std_msgs/UInt64.h>
 
-STD_MSGS_DEFINE_BUILTIN_TRAITS(uint64_t, UInt64, 0x1b2a79973e8bf53dULL, 0x7b53acb71299cb57ULL);
+STD_MSGS_DEFINE_BUILTIN_TRAITS(uint64_t, UInt64, 0x1b2a79973e8bf53dULL, 0x7b53acb71299cb57ULL)
 
 #endif

--- a/include/std_msgs/builtin_uint8.h
+++ b/include/std_msgs/builtin_uint8.h
@@ -31,6 +31,6 @@
 #include "trait_macros.h"
 #include <std_msgs/UInt8.h>
 
-STD_MSGS_DEFINE_BUILTIN_TRAITS(uint8_t, UInt8, 0x7c8164229e7d2c17ULL, 0xeb95e9231617fdeeULL);
+STD_MSGS_DEFINE_BUILTIN_TRAITS(uint8_t, UInt8, 0x7c8164229e7d2c17ULL, 0xeb95e9231617fdeeULL)
 
 #endif


### PR DESCRIPTION
Follow-up of https://github.com/ros/roscpp_core/pull/53.
Fixes `extra ‘;’ [-Wpedantic]` warning in pedantic mode.